### PR TITLE
BUG-2098  jonon prioriteetti

### DIFF
--- a/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
@@ -408,6 +408,9 @@ app.factory('ValintalaskentatulosModel', function($routeParams, ValinnanvaiheLis
         this.muutaSijoittelunStatus = function (jono, status) {
             ValintatapajonoSijoitteluUpdate.post({valintatapajonoOid: jono.oid, status: status},
                 function (updatedJono) {
+                    // updatedJono always returns prioriteetti with default int value 0, so let's set it again
+                    updatedJono.prioriteetti = jono.prioriteetti;
+
                     ValintatapajonoSijoitteluStatus.put({
                         valintatapajonoOid: jono.oid,
                         status: status

--- a/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
@@ -408,8 +408,10 @@ app.factory('ValintalaskentatulosModel', function($routeParams, ValinnanvaiheLis
         this.muutaSijoittelunStatus = function (jono, status) {
             ValintatapajonoSijoitteluUpdate.post({valintatapajonoOid: jono.oid, status: status},
                 function (updatedJono) {
-                    // updatedJono always returns prioriteetti with default int value 0, so let's set it again
-                    updatedJono.prioriteetti = jono.prioriteetti;
+                    if (updatedJono.prioriteetti === -1) {
+                      // A query for a single jono doesn't return a true prioriteetti value, but -1 as a placeholder, so let's re-set the vlaue
+                      updatedJono.prioriteetti = jono.prioriteetti;
+                    }
 
                     ValintatapajonoSijoitteluStatus.put({
                         valintatapajonoOid: jono.oid,


### PR DESCRIPTION
Ongelma: kun siirretään jono sijoitteluun/pois sijoittelusta, sen prioriteetiksi muuttuu aina 0.

Tämän syy oli siinä, että valintaperusteet-service palauttaa aina yhtä jonoa kysyessä sen prioriteetille default-arvon 0. (Prioriteeteille palautuu ei-nollia arvoja vain kun kysytään useita jonoja.) Tämä uusi arvo sitten tallentuu kun asetetaan jono sijoiteltavaksi.

Korjataan nyt niin, että laitetaan valintaperusteet-service (ks. https://github.com/Opetushallitus/valintaperusteet/pull/12 )palauttamaan defaulttina yksittäiselle jonolle prioriteetiksi -1, jotta on selvää ettei kyse ole todellisesta prioriteetista. Sitten tallennetaan -1:n sijaan UI:n muistissa oleva prioriteetti.