### PR TITLE
OY-345: Valintatapajonon tulosten tuonti palauttamaan epäonnistuneen tuonnin syy

### DIFF
--- a/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
@@ -432,12 +432,12 @@ app.factory('ValintalaskentatulosModel', function($routeParams, ValinnanvaiheLis
 });
 
 
-angular.module('valintalaskenta').controller('ValintalaskentatulosController', ['$scope', '$location', '$routeParams', '$timeout', '$upload', 'Ilmoitus',
-    'IlmoitusTila', 'Latausikkuna', 'ValintatapajonoVienti', 'ValintalaskentatulosModel',
-    'TulosXls', 'HakukohdeModel', 'HakuModel', '$http', '$log', '$modal', 'AuthService', 'UserModel', 'LocalisationService', 'json',
-    function($scope, $location, $routeParams, $timeout, $upload, Ilmoitus, IlmoitusTila, Latausikkuna,
+angular.module('valintalaskenta').controller('ValintalaskentatulosController', ['$scope', '$location', '$routeParams', '$timeout', '$upload', '$filter',
+    'Ilmoitus', 'IlmoitusTila', 'Latausikkuna', 'ValintatapajonoVienti', 'ValintalaskentatulosModel',
+    'TulosXls', 'HakukohdeModel', 'HakuModel', '$http', '$log', '$modal', 'AuthService', 'UserModel', 'LocalisationService',
+    function($scope, $location, $routeParams, $timeout, $upload, $filter, Ilmoitus, IlmoitusTila, Latausikkuna,
              ValintatapajonoVienti, ValintalaskentatulosModel, TulosXls, HakukohdeModel, HakuModel, $http, $log, $modal, AuthService, UserModel,
-             LocalisationService, json) {
+             LocalisationService) {
         "use strict";
 
         $scope.hakukohdeOid = $routeParams.hakukohdeOid;
@@ -539,7 +539,7 @@ angular.module('valintalaskenta').controller('ValintalaskentatulosController', [
                     });
                 }).error(function(data) {
                     //error
-                    Ilmoitus.avaa("Tuonti epäonnistui", "Valintatulosten tuonti epäonnistui. " + (data | json) + ". Ole hyvä ja yritä hetken päästä uudelleen.", IlmoitusTila.ERROR);
+                    Ilmoitus.avaa("Tuonti epäonnistui", "Valintatulosten tuonti epäonnistui. " + $filter('json')(data) + ". Ole hyvä ja yritä hetken päästä uudelleen.", IlmoitusTila.ERROR);
                 });
             };
 

--- a/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
@@ -539,7 +539,7 @@ angular.module('valintalaskenta').controller('ValintalaskentatulosController', [
                     });
                 }).error(function(data) {
                     //error
-                    Ilmoitus.avaa("Tuonti epäonnistui", "Valintatulosten tuonti epäonnistui. " + data + ". Ole hyvä ja yritä hetken päästä uudelleen.", IlmoitusTila.ERROR);
+                    Ilmoitus.avaa("Tuonti epäonnistui", "Valintatulosten tuonti epäonnistui. " + (data | json) + ". Ole hyvä ja yritä hetken päästä uudelleen.", IlmoitusTila.ERROR);
                 });
             };
 

--- a/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/valintalaskenta_tulos/valintalaskentatulos.js
@@ -434,10 +434,10 @@ app.factory('ValintalaskentatulosModel', function($routeParams, ValinnanvaiheLis
 
 angular.module('valintalaskenta').controller('ValintalaskentatulosController', ['$scope', '$location', '$routeParams', '$timeout', '$upload', 'Ilmoitus',
     'IlmoitusTila', 'Latausikkuna', 'ValintatapajonoVienti', 'ValintalaskentatulosModel',
-    'TulosXls', 'HakukohdeModel', 'HakuModel', '$http', '$log', '$modal', 'AuthService', 'UserModel', 'LocalisationService',
+    'TulosXls', 'HakukohdeModel', 'HakuModel', '$http', '$log', '$modal', 'AuthService', 'UserModel', 'LocalisationService', 'json',
     function($scope, $location, $routeParams, $timeout, $upload, Ilmoitus, IlmoitusTila, Latausikkuna,
              ValintatapajonoVienti, ValintalaskentatulosModel, TulosXls, HakukohdeModel, HakuModel, $http, $log, $modal, AuthService, UserModel,
-             LocalisationService) {
+             LocalisationService, json) {
         "use strict";
 
         $scope.hakukohdeOid = $routeParams.hakukohdeOid;


### PR DESCRIPTION
Toteutettu JSON-filtteröinti alertissa näytettävälle virheelle, jotta JSON-muotoiset virheviestit eivät vuoda modalin reunojen yli.