### PR TITLE
OY-3070 Synthetic applications to ataru / enable Excel import for ataru forms

### DIFF
--- a/src/main/resources/webapp/app/app-resources.js
+++ b/src/main/resources/webapp/app/app-resources.js
@@ -59,6 +59,7 @@ var koutaHakuToHaku = function (haku, ohjausparametrit) {
     tila: 'JULKAISTU',
     nimi: arvoNimiToNimi(haku.nimi),
     ataruLomakeAvain: haku.hakulomakeAtaruId,
+    synteettisetHakemukset: ohjausparametrit.synteettisetHakemukset,
     haunTunniste: null,
     kohdejoukkoUri: haku.kohdejoukkoKoodiUri,
     kohdejoukonTarkenne: haku.kohdejoukonTarkenneKoodiUri,

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -10,7 +10,7 @@ angular
           if (
             hakuModel.hakuOid.ataruLomakeAvain ||
             hakuModel.hakuOid.synteettisetHakemukset
-            ) {
+          ) {
             console.log('Getting applications from ataru.')
             return AtaruApplications.get({
               hakuOid: hakuOid,

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -201,16 +201,15 @@ angular
         }
 
         $scope.korkeakoulu = model.korkeakoulu
+
+        $scope.vieExcelEnabled = true
+        $scope.tuoExcelEnabled = true
+        $scope.excelEnabled = true
+
         if (model.hakuOid.ataruLomakeAvain) {
-          $scope.vieExcelEnabled = true
-          $scope.tuoExcelEnabled = false
-          $scope.excelEnabled = false
           $scope.hyvaksymiskirjeetEnabled = false
           $scope.reviewUrlKey = 'ataru.application.review'
         } else {
-          $scope.vieExcelEnabled = true
-          $scope.tuoExcelEnabled = true
-          $scope.excelEnabled = true
           $scope.hyvaksymiskirjeetEnabled = true
           $scope.reviewUrlKey = 'haku-app.virkailija.hakemus.esikatselu'
         }

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -201,15 +201,16 @@ angular
         }
 
         $scope.korkeakoulu = model.korkeakoulu
-
-        $scope.vieExcelEnabled = true
-        $scope.tuoExcelEnabled = true
-        $scope.excelEnabled = true
-
         if (model.hakuOid.ataruLomakeAvain) {
+          $scope.vieExcelEnabled = true
+          $scope.tuoExcelEnabled = true
+          $scope.excelEnabled = true
           $scope.hyvaksymiskirjeetEnabled = false
           $scope.reviewUrlKey = 'ataru.application.review'
         } else {
+          $scope.vieExcelEnabled = true
+          $scope.tuoExcelEnabled = false
+          $scope.excelEnabled = true
           $scope.hyvaksymiskirjeetEnabled = true
           $scope.reviewUrlKey = 'haku-app.virkailija.hakemus.esikatselu'
         }

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -7,7 +7,10 @@ angular
     function (HakukohdeHenkilotFull, AtaruApplications, HakuModel) {
       this.get = function (hakuOid, hakukohdeOid) {
         return HakuModel.promise.then(function (hakuModel) {
-          if (hakuModel.hakuOid.ataruLomakeAvain || hakuModel.hakuOid.synteettisetHakemukset) {
+          if (
+            hakuModel.hakuOid.ataruLomakeAvain ||
+            hakuModel.hakuOid.synteettisetHakemukset
+            ) {
             console.log('Getting applications from ataru.')
             return AtaruApplications.get({
               hakuOid: hakuOid,

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -207,15 +207,13 @@ angular
           $scope.excelEnabled = true
           $scope.hyvaksymiskirjeetEnabled = false
           $scope.reviewUrlKey = 'ataru.application.review'
-        }
-        else if (model.hakuOid.ataruLomakeAvain) {
+        } else if (model.hakuOid.ataruLomakeAvain) {
           $scope.vieExcelEnabled = true
           $scope.tuoExcelEnabled = false
           $scope.excelEnabled = true
           $scope.hyvaksymiskirjeetEnabled = false
           $scope.reviewUrlKey = 'ataru.application.review'
-        }
-        else {
+        } else {
           $scope.vieExcelEnabled = true
           $scope.tuoExcelEnabled = false
           $scope.excelEnabled = true

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -201,13 +201,21 @@ angular
         }
 
         $scope.korkeakoulu = model.korkeakoulu
-        if (model.hakuOid.ataruLomakeAvain) {
+        if (model.hakuOid.synteettisetHakemukset) {
           $scope.vieExcelEnabled = true
           $scope.tuoExcelEnabled = true
           $scope.excelEnabled = true
           $scope.hyvaksymiskirjeetEnabled = false
           $scope.reviewUrlKey = 'ataru.application.review'
-        } else {
+        }
+        else if (model.hakuOid.ataruLomakeAvain) {
+          $scope.vieExcelEnabled = true
+          $scope.tuoExcelEnabled = false
+          $scope.excelEnabled = true
+          $scope.hyvaksymiskirjeetEnabled = false
+          $scope.reviewUrlKey = 'ataru.application.review'
+        }
+        else {
           $scope.vieExcelEnabled = true
           $scope.tuoExcelEnabled = false
           $scope.excelEnabled = true

--- a/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
+++ b/src/main/resources/webapp/app/haku/hakukohteet/erillishaku/erillishaku.js
@@ -7,7 +7,7 @@ angular
     function (HakukohdeHenkilotFull, AtaruApplications, HakuModel) {
       this.get = function (hakuOid, hakukohdeOid) {
         return HakuModel.promise.then(function (hakuModel) {
-          if (hakuModel.hakuOid.ataruLomakeAvain) {
+          if (hakuModel.hakuOid.ataruLomakeAvain || hakuModel.hakuOid.synteettisetHakemukset) {
             console.log('Getting applications from ataru.')
             return AtaruApplications.get({
               hakuOid: hakuOid,


### PR DESCRIPTION
Synthetic applications should be saved to ataru from now on. 

- [x] Restrict import functionality to ataru admissions with synthetic applications enabled in ohjausparametrit
- [x] ~Remove the option of deleting applications from UI?~ Admission data can be still deleted from UI, applications can only be made passive elsewhere
- [x] Allow Excel imports for ataru admissions
- [x] Remove ability to save synthetic applications to haku-app