### PR TITLE
OY-5547 Päivitetään valintatulos-proxyn osoite

### DIFF
--- a/src/main/resources/webapp/app/app-resources.js
+++ b/src/main/resources/webapp/app/app-resources.js
@@ -536,7 +536,7 @@ app.factory('Parametrit', function ($resource) {
 app.factory('ValintaTulosProxy', function ($resource) {
   return $resource(
     plainUrl(
-      'valintalaskentakoostepalvelu.proxy.valintatulos.haku.hakemusoid',
+      'valintalaskentakoostepalvelu.proxy.valintatulosservice.haku.hakemusoid',
       ':hakuOid',
       ':hakemusOid'
     ),

--- a/src/main/resources/webapp/app/haku/hallinta/yhteisvalinnanhallinta.js
+++ b/src/main/resources/webapp/app/haku/hallinta/yhteisvalinnanhallinta.js
@@ -729,7 +729,7 @@ angular
             $scope.tuloskirjeet = response
           },
           function (error) {
-            console.log('ValintaTulosProxy error: ' + error)
+            console.log('ViestintapalveluProxy error: ' + error)
           }
         )
       }

--- a/src/main/resources/webapp/app/valintalaskenta-ui-web-url_properties.js
+++ b/src/main/resources/webapp/app/valintalaskenta-ui-web-url_properties.js
@@ -75,8 +75,8 @@ window.urls.addProperties({
     'valintalaskentakoostepalvelu/resources/pistesyotto/vienti',
   'valintalaskentakoostepalvelu.proxy.erillishaku.haku.hakukohde':
     'valintalaskentakoostepalvelu/resources/proxy/erillishaku/haku/$1/hakukohde/$2',
-  'valintalaskentakoostepalvelu.proxy.valintatulos.haku.hakemusoid':
-    'valintalaskentakoostepalvelu/resources/proxy/valintatulos/haku/$1/hakemusOid/$2',
+  'valintalaskentakoostepalvelu.proxy.valintatulosservice.haku.hakemusoid':
+    'valintalaskentakoostepalvelu/resources/proxy/valintatulosservice/haku/$1/hakemusOid/$2',
   'valintalaskentakoostepalvelu.proxy.valintatulosservice.hakemus.haku':
     'valintalaskentakoostepalvelu/resources/proxy/valintatulosservice/hakemus/$1/haku/$2',
   'valintalaskentakoostepalvelu.proxy.valintatulosservice.hakemus.haku.hakukohde.valintatapajono':


### PR DESCRIPTION
Päivitetään proxyn osoite vastaamaan siirrettyä rajapintaa valintalaskentakoostepalvelussa. (https://github.com/Opetushallitus/valintalaskentakoostepalvelu/pull/272)

Lisäksi korjataan yhteisvalinnan hallinnan logituksesta copy&paste virhe.